### PR TITLE
Add cascade persist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 composer.lock
 vendor/
+/nbproject/private/

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -131,7 +131,7 @@ class CronRunCommand extends BaseCommand
         $output->write($bufferedOutput);
 
         $duration = $this->getStopWatch()->getEvent($watch)->getDuration();
-        $output->writeln($statusStr . ' in ' . $duration . ' seconds');
+        $output->writeln($statusStr . ' in ' . $duration / 1000 . ' seconds');
 
 
         // Record the result

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -153,6 +153,7 @@ class CronRunCommand extends BaseCommand
         $result->setStatusCode($statusCode);
 
         $this->getEntityManager()->persist($result);
+        $this->getEntityManager()->persist($job);
     }
 
     /**

--- a/src/Entity/CronJobResult.php
+++ b/src/Entity/CronJobResult.php
@@ -42,7 +42,7 @@ class CronJobResult extends AbstractEntity implements CronJobResultInterface
 
     /**
      * @var CronJob
-     * @ORM\ManyToOne(targetEntity="CronJob", inversedBy="results")
+     * @ORM\ManyToOne(targetEntity="CronJob", inversedBy="results", cascade={"persist", "remove"})
      * @ORM\JoinColumn(nullable=false)
      */
     protected $cronJob;


### PR DESCRIPTION
Hi

I noticed I was getting the following error from Doctrine 

[Doctrine\ORM\ORMInvalidArgumentException]                                                                    
 A new entity was found through the relationship 'Shapecode\Bundle\CronBundle\Entity\CronJobResult#cronJob' that was not configured to cascade persist operations for entity: Shapecode\Bundle\CronBundle\Entity\CronJob@000000000b00504e0000000064c6deb3. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'Shapecode\Bundle\CronBundle\Entity\CronJob#__toString()' to get a clue.

The attached patch seems to fix that for me.

Regards

Steve