### PR TITLE
Long running jobs run multiple times

### DIFF
--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -61,8 +61,17 @@ class CronRunCommand extends BaseCommand
         }
 
         $jobCount = count($jobsToRun);
-        $output->writeln('Running '.$jobCount.' jobs:');
+        $output->writeln('Running ' . $jobCount . ' jobs:');
 
+        // Update the job with it's next scheduled time
+        $now = new \DateTime();
+        foreach ($jobsToRun as $job) {
+            $job->calculateNextRun();
+            $job->setLastUse($now);
+        }
+        $this->getEntityManager()->flush();
+
+        // Run the jobs
         foreach ($jobsToRun as $job) {
             $this->runJob($job, $output);
         }
@@ -98,11 +107,6 @@ class CronRunCommand extends BaseCommand
             return;
         }
 
-        // And update the job with it's next scheduled time
-        $job->calculateNextRun();
-        $job->setLastUse(new \DateTime());
-        $this->getEntityManager()->flush();
-        
         $emptyInput = new ArrayInput(array(
             'command' => $job->getCommand()
         ));
@@ -168,4 +172,5 @@ class CronRunCommand extends BaseCommand
     {
         return $this->get('debug.stopwatch');
     }
+
 }

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -98,6 +98,10 @@ class CronRunCommand extends BaseCommand
             return;
         }
 
+        // And update the job with it's next scheduled time
+        $job->calculateNextRun();
+        $job->setLastUse(new \DateTime());
+        
         $emptyInput = new ArrayInput(array(
             'command' => $job->getCommand()
         ));
@@ -136,10 +140,6 @@ class CronRunCommand extends BaseCommand
 
         // Record the result
         $this->recordJobResult($job, $duration, $bufferedOutput, $statusCode);
-
-        // And update the job with it's next scheduled time
-        $job->calculateNextRun();
-        $job->setLastUse(new \DateTime());
     }
 
     /**

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -101,6 +101,7 @@ class CronRunCommand extends BaseCommand
         // And update the job with it's next scheduled time
         $job->calculateNextRun();
         $job->setLastUse(new \DateTime());
+        $this->getEntityManager()->flush();
         
         $emptyInput = new ArrayInput(array(
             'command' => $job->getCommand()


### PR DESCRIPTION
Hi

I saw an issue recently which I think I now understand and have solved.  We have the following setup.

* The cron run command is set to run every minute
* We have some long running commands that execute reports just after midnight every day.  The run for 2-3 minutes.

We found that we received multiple copies of the reports which from the timestamps were being created about a minute apart.

I noticed that the logic to work out the next run time for a job was executed after the job had run.  This meant that if another run command was executed before the job had completed, it would be scheduled again.

In the attached patch I've moved the logic to work out the next run time ahead of the running of the jobs and flushed it to the DB.  That way another execution of the cron run command will see the new execution time, even though the jobs are still running.

This has fixed the issue for us so hopefully you'll take this pull request.

Regards

Steve