### PR TITLE
Fix application jobs getter in CronJobManager always returning empty array

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ class DemoCommand extends Command
 
 The interval spec ("*\/5 * * * *" in the above example) use the standard cronjob schedule format and can be modified whenever you choose. You have to escape the / in this example because it would close the annotation.
 You can also register your command multiple times by using the annotation more than once with different values.
-For your CronJob to be scanned and included in future runs, you must first run `php bin/console shapecode:cron:scan` - it will be scheduled to run the next time you run `php app/console schapede:cron:run`
+For your CronJob to be scanned and included in future runs, you must first run `php bin/console shapecode:cron:scan` - it will be scheduled to run the next time you run `php app/console shapecode:cron:run`
 
 Register your new Crons:
 ```sh
-$ php bin/console schapecode:cron:scan
-$ php bin/console schapecode:cron:run
+$ php bin/console shapecode:cron:scan
+$ php bin/console shapecode:cron:run
 ```
 
 Running your cron jobs automatically

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,10 @@
 
         "mtdowling/cron-expression": "~1.1"
     },
+    "require-dev":{
+        "phpunit/phpunit": "^6.1",
+        "mockery/mockery": "^1.0"
+    },
     "autoload": {
         "psr-4": {
             "Shapecode\\Bundle\\CronBundle\\": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         bootstrap="tests/bootstrap.php">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <server name="KERNEL_CLASS" value="AppKernel"/>
+        <server name="ENV_TEST_CHANNEL_READABLE" value="test"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <server name="KERNEL_CLASS" value="AppKernel"/>
-        <server name="ENV_TEST_CHANNEL_READABLE" value="test"/>
     </php>
 
     <testsuites>

--- a/src/Manager/CronJobManager.php
+++ b/src/Manager/CronJobManager.php
@@ -5,7 +5,7 @@ namespace Shapecode\Bundle\CronBundle\Manager;
 use Doctrine\Common\Annotations\Reader;
 use Shapecode\Bundle\CronBundle\Annotation\CronJob;
 use Shapecode\Bundle\CronBundle\Model\CronJobMetadata;
-use Symfony\Component\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpKernel\KernelInterface;
 

--- a/src/Manager/CronJobManager.php
+++ b/src/Manager/CronJobManager.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class CronJobManager implements CronJobManagerInterface
 {
 
-    /** @var array */
-    protected $applicationJobs = [];
+    /** @var \Shapecode\Bundle\CronBundle\Model\CronJobMetadata[]|null */
+    protected $applicationJobs;
 
-    /** @var array */
+    /** @var \Shapecode\Bundle\CronBundle\Model\CronJobMetadata[] */
     protected $jobs = [];
 
     /** @var KernelInterface */
@@ -35,7 +35,7 @@ class CronJobManager implements CronJobManagerInterface
 
     /**
      * @param KernelInterface $kernel
-     * @param Reader          $reader
+     * @param Reader $reader
      */
     public function __construct(KernelInterface $kernel, Reader $reader)
     {
@@ -45,7 +45,8 @@ class CronJobManager implements CronJobManagerInterface
     }
 
     /**
-     * @return mixed
+     * @return array|\Shapecode\Bundle\CronBundle\Model\CronJobMetadata[]
+     * @throws \ReflectionException
      */
     public function getApplicationJobs()
     {
@@ -57,7 +58,8 @@ class CronJobManager implements CronJobManagerInterface
     }
 
     /**
-     * @return array
+     * @return array|\Shapecode\Bundle\CronBundle\Model\CronJobMetadata[]
+     * @throws \ReflectionException
      */
     protected function initApplicationJobs()
     {
@@ -102,7 +104,7 @@ class CronJobManager implements CronJobManagerInterface
     /**
      * @return Application
      */
-    protected function getApplication()
+    public function getApplication()
     {
         return $this->application;
     }
@@ -110,7 +112,7 @@ class CronJobManager implements CronJobManagerInterface
     /**
      * @return Reader
      */
-    protected function getReader()
+    public function getReader()
     {
         return $this->reader;
     }

--- a/tests/Manager/CronJobManagerTest.php
+++ b/tests/Manager/CronJobManagerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Shapecode\Bundle\CronBundle\Tests\Manager;
+
+
+use Doctrine\Common\Annotations\Reader;
+use Shapecode\Bundle\CronBundle\Annotation\CronJob;
+use Shapecode\Bundle\CronBundle\Manager\CronJobManager;
+use Shapecode\Bundle\CronBundle\Model\CronJobMetadata;
+use Shapecode\Bundle\CronBundle\Tests\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+class CronJobManagerTest extends TestCase
+{
+
+    /**
+     * @var \Shapecode\Bundle\CronBundle\Manager\CronJobManager|\Mockery\Mock
+     */
+    protected $cronJobManagerMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cronJobManagerMock = \Mockery::mock(CronJobManager::class)->makePartial();
+    }
+
+    public function testGetApplicationJobs()
+    {
+        $commandMock = \Mockery::mock(Command::class)->makePartial();
+        $applicationMock = \Mockery::mock(Application::class)
+                                   ->shouldReceive('all')
+                                   ->andReturn([$commandMock])
+                                   ->getMock();
+        $expression = "* * * * *";
+        $cronJobAnnotation = new CronJob(['value' => $expression]);
+
+        $readerMock = \Mockery::mock(Reader::class)
+                              ->shouldReceive('getClassAnnotations')
+                              ->andReturn([$cronJobAnnotation])
+                              ->getMock();
+
+        $this->cronJobManagerMock->shouldReceive('getApplication')
+                                 ->andReturn($applicationMock);
+
+        $this->cronJobManagerMock->shouldReceive('getReader')
+                                 ->andReturn($readerMock);
+
+        $jobs = $this->cronJobManagerMock->getApplicationJobs();
+
+        $this->assertCount(1, $jobs);
+
+        $this->assertInstanceOf(CronJobMetadata::class, $jobs[0]);
+        $this->assertEquals($commandMock, $jobs[0]->getCommand());
+        $this->assertEquals($expression, $jobs[0]->getExpression());
+
+        // Run second time to assert the same result.
+        $jobs = $this->cronJobManagerMock->getApplicationJobs();
+        $this->assertCount(1, $jobs);
+        $this->assertInstanceOf(CronJobMetadata::class, $jobs[0]);
+        $this->assertEquals($commandMock, $jobs[0]->getCommand());
+        $this->assertEquals($expression, $jobs[0]->getExpression());
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Shapecode\Bundle\CronBundle\Tests;
+
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class TestCase extends KernelTestCase
+{
+
+    protected function tearDown()
+    {
+        \Mockery::close();
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+$file = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($file)) {
+    throw new RuntimeException('Install composer dependencies to run test suite.');
+}
+$autoload = require $file;


### PR DESCRIPTION
Application jobs property have default value of `[]`. This will never pass the is_null check in its getter.