### PR TITLE
Added attribute as alternate way of specifying cron job

### DIFF
--- a/src/Annotation/CronJob.php
+++ b/src/Annotation/CronJob.php
@@ -4,14 +4,41 @@ declare(strict_types=1);
 
 namespace Shapecode\Bundle\CronBundle\Annotation;
 
+use Attribute;
+use BadMethodCallException;
 use Doctrine\Common\Annotations\Annotation;
+
+use function Attribute;
+use function is_array;
+use function is_string;
 
 /**
  * @Annotation
  */
-final class CronJob extends Annotation
+#[Attribute(Attribute::TARGET_CLASS)]
+final class CronJob
 {
+    public string $value;
+
     public ?string $arguments = null;
 
     public int $maxInstances = 1;
+
+    /**
+     * @param string|mixed[] $data
+     */
+    public function __construct($data, ?string $arguments = null, ?int $maxInstances = null)
+    {
+        if (is_array($data)) {
+            foreach ($data as $key => $value) {
+                $this->$key = $value;
+            }
+        } elseif (is_string($data)) {
+            $this->value        = $data;
+            $this->arguments    = $arguments ?? $this->arguments;
+            $this->maxInstances = $maxInstances ?? $this->maxInstances;
+        } else {
+            throw new BadMethodCallException('$data must be an array or string');
+        }
+    }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,3 +20,4 @@ services:
 
     # service
     Shapecode\Bundle\CronBundle\Service\CommandHelper: ~
+    Shapecode\Bundle\CronBundle\Service\AttributeReader: ~

--- a/src/Service/AttributeReader.php
+++ b/src/Service/AttributeReader.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shapecode\Bundle\CronBundle\Service;
+
+use ReflectionClass;
+
+class AttributeReader
+{
+    /**
+     * @return object[]
+     */
+    public function getClassAttributes(ReflectionClass $class, ?string $filterClass = null): array
+    {
+        $attribs = [];
+        foreach ($class->getAttributes($filterClass) as $attribute) {
+            $attribs[] = $attribute->newInstance();
+        }
+
+        return $attribs;
+    }
+}

--- a/tests/Annotation/CronJobTest.php
+++ b/tests/Annotation/CronJobTest.php
@@ -8,6 +8,8 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Shapecode\Bundle\CronBundle\Annotation\CronJob;
+use Shapecode\Bundle\CronBundle\Service\AttributeReader;
+use Shapecode\Bundle\CronBundle\Tests\Annotation\data\TestAttributeModel;
 use Shapecode\Bundle\CronBundle\Tests\Annotation\data\TestModel;
 
 use function assert;
@@ -46,5 +48,20 @@ final class CronJobTest extends TestCase
         self::assertEquals('ls', $annotation->value);
         self::assertEquals('-l', $annotation->arguments);
         self::assertEquals(3, $annotation->maxInstances);
+    }
+
+    public function testAttributeReader(): void
+    {
+        $reader = new AttributeReader();
+
+        $ref         = new ReflectionClass(TestAttributeModel::class);
+        $annotations = $reader->getClassAttributes($ref, CronJob::class);
+        $this->assertCount(1, $annotations);
+        $annotation = $annotations[0];
+        $this->assertInstanceOf(CronJob::class, $annotation);
+
+        $this->assertEquals('ls', $annotation->value);
+        $this->assertEquals('-l', $annotation->arguments);
+        $this->assertEquals(3, $annotation->maxInstances);
     }
 }

--- a/tests/Annotation/data/TestAttributeModel.php
+++ b/tests/Annotation/data/TestAttributeModel.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shapecode\Bundle\CronBundle\Tests\Annotation\data;
+
+#[CronJob('ls', arguments: '-l', maxInstances: 3)]
+class TestAttributeModel
+{
+}


### PR DESCRIPTION
I've made some changes to that allow the `CronJob` class to be used either as a doctrine-style annotation, or as a PHP8-style attribute. The purpose of this is just to allow a more idiomatically PHP 8 way of specifying cron jobs. I have added a test for the attribute parser, the added logic is overall quite simple.

Because the only PHP 8-exclusive syntax used is a single-line attribute (which will be parsed by PHP 7 as a comment), there should be no problems running this on PHP 7 (there is a run-time version check that avoids executing the PHP 8 reflection code).

The only backwards-incompatible change is that `CronJob` no longer inherits from `Attribute`. This was necessary because `Attribute`'s non-overridable constructor was not suitable for use as an attribute. This could be changed to use two separate classes, but it would make a potential future migration more tricky.