### PR TITLE
fix DateTime -> DateTimeImmutable

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -15,10 +15,10 @@ abstract class AbstractEntity
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected int|null $id = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     protected DateTimeInterface|null $createdAt = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     protected DateTimeInterface|null $updatedAt = null;
 
     public function getId(): int|null

--- a/src/Entity/CronJob.php
+++ b/src/Entity/CronJob.php
@@ -36,7 +36,7 @@ class CronJob extends AbstractEntity
     #[ORM\Column(type: Types::STRING)]
     private string $period;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private DateTimeInterface|null $lastUse = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]

--- a/src/Entity/CronJobResult.php
+++ b/src/Entity/CronJobResult.php
@@ -14,7 +14,7 @@ use function sprintf;
 #[ORM\Entity(repositoryClass: CronJobResultRepository::class)]
 class CronJobResult extends AbstractEntity
 {
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private DateTimeInterface $runAt;
 
     #[ORM\Column(type: Types::FLOAT)]


### PR DESCRIPTION
psr clock is immutable: https://github.com/php-fig/clock/blob/master/src/ClockInterface.php#L12
```
Error thrown while running command "shapecode:cron:run". Message: "Could not convert PHP value of type Symfony\Component\Clock\DatePoint to type Doctrine\DBAL\Types\DateTimeType. Expected one of the following types: null, DateTime." {"exception":"[object] (Doctrine\\DBAL\\Types\\Exception\\InvalidType(code: 0): Could not convert PHP value of type Symfony\\Component\\Clock\\DatePoint to type Doctrine\\DBAL\\Types\\DateTimeType. Expected one of the following types: null, DateTime. at /var/www/xxx/vendor/doctrine/dbal/src/Types/Exception/InvalidType.php:51)","command":"shapecode:cron:run","message":"Could not convert PHP value of type Symfony\\Component\\Clock\\DatePoint to type Doctrine\\DBAL\\Types\\DateTimeType. Expected one of the following types: null, DateTime."} []
```