### PR TITLE
fix delete command for postgres

### DIFF
--- a/src/Repository/CronJobRepository.php
+++ b/src/Repository/CronJobRepository.php
@@ -40,10 +40,11 @@ class CronJobRepository extends ServiceEntityRepository
             ->andWhere(
                 $qb->expr()->orX(
                     'p.command = :command',
-                    'p.id = :command',
+                    'p.id = :commandInt',
                 ),
             )
             ->setParameter('command', $commandOrId, Types::STRING)
+            ->setParameter('commandInt', (int) $commandOrId, Types::INTEGER)
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
```
Error thrown while running command "shapecode:cron:scan --no-interaction --ansi". Message: "An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: "app:test" CONTEXT:  unnamed portal parameter $2 = '...'" {"exception":"[object] (Doctrine\\DBAL\\Exception\\DriverException(code: 7): An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: \"app:test\"\nCONTEXT:  unnamed portal parameter $2 = '...' at /var/www/xxx/vendor/doctrine/dbal/src/Driver/API/PostgreSQL/ExceptionConverter.php:87)\n[previous exception] [object] (Doctrine\\DBAL\\Driver\\PDO\\Exception(code: 7): SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: \"app:test\"\nCONTEXT:  unnamed portal parameter $2 = '...' at /var/www/xxx/vendor/doctrine/dbal/src/Driver/PDO/Exception.php:28)\n[previous exception] [object] (PDOException(code: 22P02): SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: \"app:test\"\nCONTEXT:  unnamed portal parameter $2 = '...' at /var/www/xxx/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130)","command":"shapecode:cron:scan --no-interaction --ansi","message":"An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: \"app:test\"\nCONTEXT:  unnamed portal parameter $2 = '...'"} []
```