### PR TITLE
Move calculateNextRun to execute after cron completed. & fixed issues when running multiple instances 

### DIFF
--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -117,7 +117,11 @@ final class CronRunCommand extends Command
                 } catch (ProcessTimedOutException) {
                 }
 
-                $job = $running->cronJob->decreaseRunningInstances()->calculateNextRun();
+                $job = $running->cronJob->decreaseRunningInstances();
+
+                if ($job->getRunningInstances() == 0) {
+                    $job->calculateNextRun();
+                }
 
                 $this->entityManager->persist($job);
                 $this->entityManager->flush();

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -73,7 +73,6 @@ final class CronRunCommand extends Command
             $job->increaseRunningInstances();
             $process = $this->runJob($job);
 
-            $job->calculateNextRun();
             $job->setLastUse($now);
 
             $this->entityManager->persist($job);
@@ -118,7 +117,7 @@ final class CronRunCommand extends Command
                 } catch (ProcessTimedOutException) {
                 }
 
-                $job = $running->cronJob->decreaseRunningInstances();
+                $job = $running->cronJob->decreaseRunningInstances()->calculateNextRun();
 
                 $this->entityManager->persist($job);
                 $this->entityManager->flush();

--- a/src/Command/CronRunCommand.php
+++ b/src/Command/CronRunCommand.php
@@ -70,6 +70,11 @@ final class CronRunCommand extends Command
                 continue;
             }
 
+            if ($job->getRunningInstances() >= $job->getMaxInstances()) {
+                $style->notice('cronjob will not be executed. The number of maximum instances has been exceeded.');
+                continue;
+            }
+
             $job->increaseRunningInstances();
             $process = $this->runJob($job);
 
@@ -80,11 +85,7 @@ final class CronRunCommand extends Command
 
             $processes->add(new CronJobRunning($job, $process));
 
-            if ($job->getRunningInstances() > $job->getMaxInstances()) {
-                $style->notice('cronjob will not be executed. The number of maximum instances has been exceeded.');
-            } else {
-                $style->success('cronjob started successfully and is running in background');
-            }
+            $style->success('cronjob started successfully and is running in background');
         }
 
         $style->section('Summary');
@@ -112,12 +113,14 @@ final class CronRunCommand extends Command
                     $running->process->checkTimeout();
 
                     if ($running->process->isRunning() === true) {
-                        break;
+                        continue;
                     }
                 } catch (ProcessTimedOutException) {
                 }
 
-                $job = $running->cronJob->decreaseRunningInstances();
+                $job = $running->cronJob;
+                $this->entityManager->refresh($job);
+                $job->decreaseRunningInstances();
 
                 if ($job->getRunningInstances() == 0) {
                     $job->calculateNextRun();


### PR DESCRIPTION
When we running this with multiple instances even though we set maximum instances to > 1 number it always run in single instance. its because 
`if ($job->getNextRun() > $now) `
This Conditions always rerturn true once the first instance of a cron job started. By moving the calculation of the next run time to the end of the cron job, all instances will execute the main logic first before checking if they should continue running based on the next run time condition. This should allow multiple instances to run concurrently without being blocked by the condition.