### PR TITLE
Fixes wrong datetime type usage

### DIFF
--- a/src/Command/CronProcessCommand.php
+++ b/src/Command/CronProcessCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shapecode\Bundle\CronBundle\Command;
 
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
@@ -136,7 +137,7 @@ final class CronProcessCommand extends Command
             $timeTaken,
             $statusCode,
             $buffer,
-            $this->clock->now(),
+            DateTime::createFromImmutable($this->clock->now()),
         );
 
         $this->entityManager->persist($result);


### PR DESCRIPTION
Fixes issue https://github.com/shapecode/cron-bundle/issues/69

> Could not convert PHP value of type Symfony\Component\Clock\DatePoint to type Doctrine\DBAL\Types\DateTimeType. Expected one of the following types: null, DateTime.

Based on: https://github.com/shapecode/cron-bundle/pull/66/files (fix for https://github.com/shapecode/cron-bundle/issues/65)